### PR TITLE
fix(styles): remove margins from math elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,14 +1,14 @@
 body { text-align: center; }
-body * { max-width: 720px; margin: 0 auto; text-align: center; }
+body *:not(math, math *) { max-width: 720px; margin: 0 auto; text-align: center; }
 textarea { width: 100%; text-align: left; }
 #output-html { margin-top: 2em; margin-bottom: 1em; }
 #output-text { border: solid; min-height: 2em; }
 
 .description {
-    font-size: small;    
+    font-size: small;
 }
 
-footer { 
+footer {
     position: fixed;
     top: calc(100vh - 3ex);
 }


### PR DESCRIPTION
This PR updates the CSS fixing a display bug in webkit browsers. Before this change, safari stretches the math elements into an unreadable state.

<img width="1469" alt="Screenshot 2023-11-15 at 9 42 53 AM" src="https://github.com/osanshouo/latex2mathml-web/assets/25532785/d75114a8-99ae-4cb4-81b5-d16675e8a347">

After this change, the rendered MathML is displayed consistently across Safari, Firefox, and Chrome.

<img width="1468" alt="Screenshot 2023-11-15 at 9 44 48 AM" src="https://github.com/osanshouo/latex2mathml-web/assets/25532785/db13e1e0-a1f0-4c1f-a171-09e0297baed4">
